### PR TITLE
Allow override of repo1 maven repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Usage (as script in `package.json`):
   }
 }
 ```
+
+Maven Override:
+
+You can use the `MAVEN_BASE_URL` environment variable to override the public `https://repo1.maven.org/maven2` URL.

--- a/install.js
+++ b/install.js
@@ -1,6 +1,7 @@
 const http = require('https');
 const fs = require('fs');
 const version = require('./package.json').version;
+const mavenBaseURL = process.env.MAVEN_BASE_URL || 'https://repo1.maven.org/maven2';
 
 function download(url, dest, cb) {
   const errorHandler = (message) => {
@@ -26,7 +27,7 @@ function download(url, dest, cb) {
 }
 
 const wiremockVersion = version.split('-').shift();
-const url = 'https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/'
+const url = mavenBaseURL + '/com/github/tomakehurst/wiremock-standalone/'
   + `${wiremockVersion}/wiremock-standalone-${wiremockVersion}.jar`;
 
 console.log(`Downloading WireMock standalone from Maven Central...\n  ${url}`);


### PR DESCRIPTION
We have a use-case at our company where we don't have access to repo1, but instead have access to an internal enterprise proxy. This change allows an environment variable override to be set so that we can point to our internal proxy of repo1 that also has our hosted maven repositories in it.