### PR TITLE
fixed download error message to be compatible with node v10+

### DIFF
--- a/install.js
+++ b/install.js
@@ -5,7 +5,7 @@ const mavenBaseURL = process.env.MAVEN_BASE_URL || 'https://repo1.maven.org/mave
 
 function download(url, dest, cb) {
   const errorHandler = (message) => {
-    fs.unlink(dest);
+    fs.unlink(dest, () => {});
     return cb(message);
   };
 


### PR DESCRIPTION
As of node v10.0 the callback parameter of unlink is no longer optional as shown at the following link:
https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback

This was causing the download error handler to error out giving an unhelpful error message ([ERR_INVALID_CALLBACK]: Callback must be a function)