### PR TITLE
update wiremock-standalone to wiremock-jre8-standalone

### DIFF
--- a/install.js
+++ b/install.js
@@ -8,7 +8,7 @@ const options = {
   version: process.env.WIREMOCK_VERSION || config.version,
   mavenRepoURL: process.env.MAVEN_BASE_URL || process.env.MAVEN_REPO_URL || config.mavenRepoURL || 'https://repo1.maven.org/maven2',
 };
-const mavenPath = 'com/github/tomakehurst/wiremock-standalone';
+const mavenPath = 'com/github/tomakehurst/wiremock-jre8-standalone';
 
 function resolveVersion() {
   return axios.get(`${options.mavenRepoURL}/${mavenPath}/maven-metadata.xml`)
@@ -34,7 +34,7 @@ function download(url, dest) {
 
 resolveVersion()
   .then((version) => {
-    const url = `${options.mavenRepoURL}/${mavenPath}/${version}/wiremock-standalone-${version}.jar`;
+    const url = `${options.mavenRepoURL}/${mavenPath}/${version}/wiremock-jre8-standalone-${version}.jar`;
 
     console.log(`Downloading WireMock standalone from Maven Central...\n ${url}`);
 


### PR DESCRIPTION
Since Java7 version is deprecated, it would be worthwhile to stay current and use jre8 version which does have a few versions available 2.21.x - 2.29.x

closes #14