### PR TITLE
fix: Made the version resolution take latest non-beta version number from the versions list.

### DIFF
--- a/install.js
+++ b/install.js
@@ -24,8 +24,8 @@ function resolveVersion() {
         return options.version;
       }
 
-      // latest
-      return meta.match(/<release>([.\d]+)<\/release>/m)[1];
+      // latest stable
+      return meta.match(/(?<=<version>)[.\d]+(?=<\/version>)/g).pop();
     });
 }
 


### PR DESCRIPTION
# What:
A bug fix to the `Error: Cannot read property '1' of null` error message encountered during wiremock version resolution upon doing `yarn install`.

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
	<groupId>com.github.tomakehurst</groupId>
	<artifactId>wiremock-standalone</artifactId>
	<versioning>
		<latest>3.0.0-beta-2</latest>
		<release>3.0.0-beta-2</release>
		<versions>
                        ...
			<version>2.27.1</version>
			<version>2.27.2</version>
			<version>3.0.0-beta-1</version>
			<version>3.0.0-beta-2</version>
		</versions>
		<lastUpdated>20221230190922</lastUpdated>
	</versioning>
</metadata>
```

Above is the example of currently returned `maven-metadata.xml` file. In this case, a fix is grabbing a `2.27.2` version number. Feel free to test it out.

# Why:
 - The `install.js` script is failing due encountering an unexpected `-beta-2` suffixed version pattern within the `release` xml tag. _(more details within the issue #19)_

# Notes:
 - This fix assumes that we don't want to be using the `beta` wiremock versions. If we do, then pattern would need be modified in a different way - one that allows optional `beta` suffixes.